### PR TITLE
remove Utils.escapeHTML as it was not necessary and was cause wrong encodings #4

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -221,9 +221,9 @@ class CucumberJsJsonReporter extends WDIOReporter {
 
         return {
             keyword: FEATURE,
-            description: Utils.escapeHTML(featureData.description || ''),
+            description: (featureData.description || ''),
             line: parseInt(featureData.uid.substring(featureName.length, featureData.uid.length)),
-            name: Utils.escapeHTML(featureName),
+            name: featureName,
             tags: featureData.tags || '',
             elements: [],
             id: featureName.replace(/ /g, '-').toLowerCase(),
@@ -253,8 +253,8 @@ class CucumberJsJsonReporter extends WDIOReporter {
 
         return {
             keyword: SCENARIO,
-            description: Utils.escapeHTML(scenarioData.description || ''),
-            name: Utils.escapeHTML(scenarioName),
+            description: (scenarioData.description || ''),
+            name: scenarioName,
             tags: scenarioData.tags || '',
             id: `${ id };${ scenarioName.replace(/ /g, '-').toLowerCase() }`,
             steps: [],
@@ -290,7 +290,7 @@ class CucumberJsJsonReporter extends WDIOReporter {
         const stepResult = {
             arguments: stepData.argument ? [ stepData.argument ] : [],
             keyword: keyword,
-            name: Utils.escapeHTML(title),
+            name: title,
             result: {
                 status: stepData.state || '',
                 duration: (stepData._duration || 0) * 1000000,

--- a/lib/tests/__snapshots__/reporter.spec.js.snap
+++ b/lib/tests/__snapshots__/reporter.spec.js.snap
@@ -78,7 +78,7 @@ Object {
   "description": "",
   "id": "create-passed-feature;given-i-open-\\"http://webdriver.io/\\"",
   "keyword": "Scenario",
-  "name": "Given I open &quot;http://webdriver.io/&quot;",
+  "name": "Given I open \\"http://webdriver.io/\\"",
   "steps": Array [],
   "tags": "",
 }
@@ -109,7 +109,7 @@ Object {
   "match": Object {
     "location": "can not be determined with webdriver.io",
   },
-  "name": "I open &quot;http://webdriver.io/&quot;",
+  "name": "I open \\"http://webdriver.io/\\"",
   "result": Object {
     "duration": 0,
     "status": "pending",
@@ -125,7 +125,7 @@ Object {
   "match": Object {
     "location": "can not be determined with webdriver.io",
   },
-  "name": "I open &quot;http://webdriver.io/&quot;",
+  "name": "I open \\"http://webdriver.io/\\"",
   "result": Object {
     "duration": 0,
     "status": "pending",

--- a/lib/tests/__snapshots__/utils.spec.js.snap
+++ b/lib/tests/__snapshots__/utils.spec.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`utils escapeHTML should return an empty string and escape nothing 1`] = `"&lt;div id=&quot;feature-chart&quot;&gt;&amp;&lt;/div&gt;"`;
-
 exports[`utils getFailedMessage should return an error message if the status is "failed" 1`] = `
 Object {
   "error_message": "Actual: WebdriverIO · Next-gen WebDriver test framework for Node.js

--- a/lib/tests/reporter.spec.js
+++ b/lib/tests/reporter.spec.js
@@ -208,7 +208,6 @@ describe('reporter', () => {
 
     describe('getFeatureDataObject', () => {
         it('should be able to to create a feature JSON data object', () => {
-            const escapeHTMLSpy = jest.spyOn(Utils, 'escapeHTML');
 
             expect(tmpReporter.getFeatureDataObject(
                 SUITE_FEATURE_STATS,
@@ -218,20 +217,17 @@ describe('reporter', () => {
                     }
                 },
             )).toMatchSnapshot();
-            expect(escapeHTMLSpy).toHaveBeenCalledTimes(2);
         });
     });
 
     describe('getScenarioDataObject', () => {
         it('should be able to to create a scenario JSON data object', () => {
-            const escapeHTMLSpy = jest.spyOn(Utils, 'escapeHTML');
 
             expect(tmpReporter.getScenarioDataObject(
                 TEST_SCENARIO_STATS,
                 'create-passed-feature',
                 'Open website',
             )).toMatchSnapshot();
-            expect(escapeHTMLSpy).toHaveBeenCalledTimes(2);
         });
     });
 

--- a/lib/tests/utils.spec.js
+++ b/lib/tests/utils.spec.js
@@ -2,16 +2,6 @@ import Utils from '../utils';
 import { TEST_SCENARIO_STATS, TEST_SCENARIO_STATS_ERROR } from './__mocks__/mocks';
 
 describe('utils', () => {
-    describe('escapeHTML', () => {
-        it('should return an empty string and escape nothing', () => {
-            expect(Utils.escapeHTML('')).toEqual('');
-        });
-
-        it('should return an empty string and escape nothing', () => {
-            expect(Utils.escapeHTML('<div id="feature-chart">&</div>')).toMatchSnapshot();
-        });
-    });
-
     describe('getFailedMessage', () => {
         it('should not return an error message if the status is "passed"', () => {
             expect(Utils.getFailedMessage(TEST_SCENARIO_STATS)).toEqual({});

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,23 +1,6 @@
 import { FAILED } from './constants';
 
 /**
- * Escape html in strings
- *
- * @param   {string}  string
- * @return  {string}
- */
-function escapeHTML(string) {
-    return !string
-        ? string
-        : string
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
-}
-
-/**
  * Add a failed message
  *
  * @param {object}  testObject
@@ -52,7 +35,6 @@ function containsSteps(steps){
 
 const utilFunctions = {
     containsSteps,
-    escapeHTML,
     getFailedMessage
 };
 


### PR DESCRIPTION
remove Utils.escapeHTML as it was not necessary and was cause wrong encodings. fixes #4 