### PR TITLE
Fix prohibited symbols in filename

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -232,7 +232,7 @@ class CucumberJsJsonReporter extends WDIOReporter {
             uri: 'Can not be determined',
             tags: featureData.tags || '',
             elements: [],
-            id: featureName.replace(/ /g, '-').toLowerCase(),
+            id: featureName.replace(/[\\/?%*:|"<> ]/g, '-').toLowerCase(),
             ...instanceMetadata,
         };
     }


### PR DESCRIPTION
Hi!
I've faced the issue on windows - JSON files were not generated. That happened because we had " symbols in feature names. This PR fixes all prohibited symbols in filename.