### PR TITLE
Update gherkin to 8.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@wdio/logger": "^5.13.2",
     "@wdio/reporter": "^5.15.2",
     "fs-extra": "^8.1.0",
-    "gherkin": "^7.0.3"
+    "gherkin": "^8.2.1"
   },
   "peerDependencies": {
     "@wdio/cucumber-framework": "^5.11.0"


### PR DESCRIPTION
Gherkin 7 uses a binary which is detected as possible malware, as discussed here: https://github.com/cucumber/cucumber/issues/812

This PR updates the gherkin dependency to a version without the binary executable.