### PR TITLE
Hotfix: properly determine metadata for devtools automation protocol

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -32,8 +32,9 @@ function determineMetadata(data) {
     const currentConfigCapabilities = data.config.capabilities || {};
     const { w3cCaps = {} } = requestedCapabilities;
     const metadata = currentConfigCapabilities['cjson:metadata'] // For WDIO V6
-    || (w3cCaps.alwaysMatch && w3cCaps.alwaysMatch['cjson:metadata']) || {} // When an app is used to test
+    || (w3cCaps.alwaysMatch && w3cCaps.alwaysMatch['cjson:metadata']) // When an app is used to test
     || optsCaps['cjson:metadata']; // devtools
+    || {} 
 
     // When an app is used to test
     if (currentConfigCapabilities.app || currentConfigCapabilities.testobject_app_id || metadata.app) {

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -28,11 +28,12 @@ import { NOT_KNOWN } from './constants';
 function determineMetadata(data) {
     let instanceData;
     const currentCapabilities = data.capabilities;
+    const { capabilities: optsCaps = {}, requestedCapabilities = {} } = browser.options || {}
     const currentConfigCapabilities = data.config.capabilities || {};
-    const metadata = currentConfigCapabilities['cjson:metadata']
-        // For WDIO V6
-        || browser.options.requestedCapabilities.w3cCaps.alwaysMatch['cjson:metadata']
-        || {};
+    const { w3cCaps = {} } = requestedCapabilities;
+    const metadata = currentConfigCapabilities['cjson:metadata'] // For WDIO V6
+    || (w3cCaps.alwaysMatch && w3cCaps.alwaysMatch['cjson:metadata']) || {} // When an app is used to test
+    || optsCaps['cjson:metadata']; // devtools
 
     // When an app is used to test
     if (currentConfigCapabilities.app || currentConfigCapabilities.testobject_app_id || metadata.app) {

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -28,13 +28,13 @@ import { NOT_KNOWN } from './constants';
 function determineMetadata(data) {
     let instanceData;
     const currentCapabilities = data.capabilities;
-    const { capabilities: optsCaps = {}, requestedCapabilities = {} } = browser.options || {}
+    const { capabilities: optsCaps = {}, requestedCapabilities = {} } = browser.options;
     const currentConfigCapabilities = data.config.capabilities || {};
     const { w3cCaps = {} } = requestedCapabilities;
     const metadata = currentConfigCapabilities['cjson:metadata'] // For WDIO V6
     || (w3cCaps.alwaysMatch && w3cCaps.alwaysMatch['cjson:metadata']) // When an app is used to test
-    || optsCaps['cjson:metadata']; // devtools
-    || {} 
+    || optsCaps['cjson:metadata'] // devtools
+    || {};
 
     // When an app is used to test
     if (currentConfigCapabilities.app || currentConfigCapabilities.testobject_app_id || metadata.app) {

--- a/lib/tests/__snapshots__/metadata.spec.js.snap
+++ b/lib/tests/__snapshots__/metadata.spec.js.snap
@@ -151,6 +151,38 @@ Object {
 }
 `;
 
+exports[`metadata determineMetadata should return metadata based on the browser.options.capabilities 1`] = `
+Object {
+  "metadata": Object {
+    "browser": Object {
+      "name": "mock-browserName",
+      "version": "mock-browserVersion",
+    },
+    "device": "not known",
+    "platform": Object {
+      "name": "not known",
+      "version": "not known",
+    },
+  },
+}
+`;
+
+exports[`metadata determineMetadata should return metadata based on the browser.options.capabilities 2`] = `
+Object {
+  "metadata": Object {
+    "browser": Object {
+      "name": "mock-browserName",
+      "version": "mock-browserVersion",
+    },
+    "device": "not known",
+    "platform": Object {
+      "name": "not known",
+      "version": "not known",
+    },
+  },
+}
+`;
+
 exports[`metadata determineMetadata should return metadata based on the requestedCapabilities.w3cCaps.alwaysMatch 1`] = `
 Object {
   "metadata": Object {

--- a/lib/tests/__snapshots__/metadata.spec.js.snap
+++ b/lib/tests/__snapshots__/metadata.spec.js.snap
@@ -167,7 +167,7 @@ Object {
 }
 `;
 
-exports[`metadata determineMetadata should return metadata based on the browser.options.capabilities 2`] = `
+exports[`metadata determineMetadata should return metadata based on the browser.options.capabilities if w3cCaps is empty 1`] = `
 Object {
   "metadata": Object {
     "browser": Object {

--- a/lib/tests/metadata.spec.js
+++ b/lib/tests/metadata.spec.js
@@ -273,7 +273,7 @@ describe('metadata', () => {
             determineAppDataSpy.mockClear();
         });
 
-        it('should return metadata based on the browser.options.capabilities', () => {
+        it('should return metadata based on the browser.options.capabilities if w3cCaps is empty', () => {
             global.browser = {
                 options: {
                     requestedCapabilities: {

--- a/lib/tests/metadata.spec.js
+++ b/lib/tests/metadata.spec.js
@@ -273,6 +273,44 @@ describe('metadata', () => {
             determineAppDataSpy.mockClear();
         });
 
+        it('should return metadata based on the browser.options.capabilities', () => {
+            global.browser = {
+                options: {
+                    requestedCapabilities: {
+                        w3cCaps:{
+
+                        }
+                    },
+                    capabilities: {
+                        browserName: 'chrome',
+                        'cjson:metadata': {},
+                    }
+                },
+            };
+
+            const determineAppDataSpy = jest.spyOn(Metadata, 'determineBrowserData').mockReturnValue(browserMockData);
+
+            expect(Metadata.determineMetadata(WDIO6_RUNNER_STATS)).toMatchSnapshot();
+            determineAppDataSpy.mockClear();
+        });
+
+        it('should return metadata based on the browser.options.capabilities', () => {
+            global.browser = {
+                options: {
+                    capabilities: {
+                        browserName: 'chrome',
+                        'cjson:metadata': {},
+                    },
+                },
+
+            };
+
+            const determineAppDataSpy = jest.spyOn(Metadata, 'determineBrowserData').mockReturnValue(browserMockData);
+
+            expect(Metadata.determineMetadata(WDIO6_RUNNER_STATS)).toMatchSnapshot();
+            determineAppDataSpy.mockClear();
+        });
+
         it('should call determineBrowserData when there is no way to  determine the app data', () => {
             Metadata.determineMetadata(SMALL_RUNNER_STATS);
 


### PR DESCRIPTION
As title reads.
Recently released version 2.0.0 crashes with the following error:
```js
2020-04-30T22:46:21.296Z ERROR @wdio/local-runner: Failed launching test session: TypeError: Cannot read property 'cjson:metadata' of undefined
    at Object.determineMetadata (/Users/[REDACTED]/Repos/[REDACTED]/node_modules/wdio-cucumberjs-json-reporter/build/metadata.js:46:63)
    at CucumberJsJsonReporter.onRunnerStart (/Users/[REDACTED]/Repos/[REDACTED]/node_modules/wdio-cucumberjs-json-reporter/build/reporter.js:86:49)
    at CucumberJsJsonReporter.<anonymous> (/Users/[REDACTED]/Repos/[REDACTED]/node_modules/@wdio/reporter/build/index.js:64:12)
    at CucumberJsJsonReporter.emit (events.js:311:20)
    at CucumberJsJsonReporter.EventEmitter.emit (domain.js:482:12)
    at /Users/[REDACTED]/Repos/[REDACTED]/node_modules/@wdio/runner/build/reporter.js:38:49
    at Array.forEach (<anonymous>)
    at BaseReporter.emit (/Users/[REDACTED]/Repos/[REDACTED]/node_modules/@wdio/runner/build/reporter.js:38:20)
    at Runner.run (/Users/[REDACTED]/Repos/[REDACTED]/node_modules/@wdio/runner/build/index.js:110:19)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```
`alwaysMatch` isn't set for `devtools` automation protocol.
